### PR TITLE
Request specs

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -51,8 +51,8 @@ gem 'bootsnap', require: false
 group :development, :test do
   gem 'debug', platforms: %i[mri mingw x64_mingw]
   gem 'factory_bot_rails'
-  gem 'rspec-rails'
   gem 'rails-controller-testing'
+  gem 'rspec-rails'
 end
 
 group :development do

--- a/Gemfile
+++ b/Gemfile
@@ -52,6 +52,7 @@ group :development, :test do
   gem 'debug', platforms: %i[mri mingw x64_mingw]
   gem 'factory_bot_rails'
   gem 'rspec-rails'
+  gem 'rails-controller-testing'
 end
 
 group :development do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -147,6 +147,10 @@ GEM
       activesupport (= 7.0.5)
       bundler (>= 1.15.0)
       railties (= 7.0.5)
+    rails-controller-testing (1.0.5)
+      actionpack (>= 5.0.1.rc1)
+      actionview (>= 5.0.1.rc1)
+      activesupport (>= 5.0.1.rc1)
     rails-dom-testing (2.0.3)
       activesupport (>= 4.2.0)
       nokogiri (>= 1.6)
@@ -236,6 +240,7 @@ DEPENDENCIES
   pg (~> 1.1)
   puma (~> 5.0)
   rails (~> 7.0.5)
+  rails-controller-testing
   rspec-rails
   rubocop (>= 1.0, < 2.0)
   sprockets-rails

--- a/spec/requests/posts_show_spec.rb
+++ b/spec/requests/posts_show_spec.rb
@@ -1,0 +1,24 @@
+require 'rails_helper'
+
+RSpec.describe 'Posts/show', type: :request do
+  describe 'GET user_post_path' do
+    let!(:user) { User.create(name: 'Ariel', post_counter: 0) }
+    let!(:post) { Post.create(author: user, title: 'Microverse', comments_counter: 0, likes_counter: 0) }
+
+    before :each do
+      get user_post_path(:user, :post)
+    end
+
+    it 'should have a http status of 200(correct status)' do
+      expect(response).to have_http_status(200)
+    end
+
+    it 'should render posts/show view' do
+      expect(response).to render_template('posts/show')
+    end
+
+    it 'should include the placeholder text' do
+      expect(response.body).to include('Post show')
+    end
+  end
+end

--- a/spec/requests/posts_spec.rb
+++ b/spec/requests/posts_spec.rb
@@ -1,0 +1,23 @@
+require 'rails_helper'
+
+RSpec.describe 'Posts', type: :request do
+  describe 'GET user_posts_path' do
+    let!(:user) { User.create(name: 'Ariel', post_counter: 0) }
+
+    before :each do
+      get user_posts_path(:user)
+    end
+
+    it 'should have a http status of 200(correct status)' do
+      expect(response).to have_http_status(200)
+    end
+
+    it 'should render post/index view' do
+      expect(response).to render_template('posts/index')
+    end
+
+    it 'should include the placeholder text' do
+      expect(response.body).to include('Post index')
+    end
+  end
+end

--- a/spec/requests/users_show_spec.rb
+++ b/spec/requests/users_show_spec.rb
@@ -1,0 +1,23 @@
+require 'rails_helper'
+
+RSpec.describe 'Users/show', type: :request do
+  describe 'GET /users/:user_id' do
+    let!(:user) { User.create(name: 'Ariel', post_counter: 0) }
+
+    before :each do
+      get user_path(:user)
+    end
+
+    it 'should have a http status of 200(correct status)' do
+      expect(response).to have_http_status(200)
+    end
+
+    it 'should render users/show view' do
+      expect(response).to render_template('users/show')
+    end
+
+    it 'should include the placeholder text' do
+      expect(response.body).to include('Users show')
+    end
+  end
+end

--- a/spec/requests/users_spec.rb
+++ b/spec/requests/users_spec.rb
@@ -11,7 +11,7 @@ RSpec.describe 'Users', type: :request do
     end
 
     it 'should render users/index view' do
-      expect(response).to render_template("users/index")
+      expect(response).to render_template('users/index')
     end
 
     it 'should include the placeholder text' do

--- a/spec/requests/users_spec.rb
+++ b/spec/requests/users_spec.rb
@@ -1,0 +1,21 @@
+require 'rails_helper'
+
+RSpec.describe 'Users', type: :request do
+  describe 'GET /users' do
+    before :each do
+      get users_path
+    end
+
+    it 'should have a http status of 200(correct status)' do
+      expect(response).to have_http_status(200)
+    end
+
+    it 'should render users/index view' do
+      expect(response).to render_template("users/index")
+    end
+
+    it 'should include the placeholder text' do
+      expect(response.body).to include('Users index')
+    end
+  end
+end


### PR DESCRIPTION
In this milestone, we have created request specs for the controller actions of the 4 different routes we currently have in our application: 
- route to `users#index` 
- route to `users#show` 
- route to `posts#index` 
- route to `posts#show`

For each action we have checked:
- If the response status was correct.
- If a correct template was rendered.
- If the response body includes correct placeholder text.